### PR TITLE
printbot: Do the printing in thread

### DIFF
--- a/printbot.py
+++ b/printbot.py
@@ -28,6 +28,7 @@ from pytox import Tox, ToxAV
 from time import sleep
 from os.path import exists
 from subprocess import call
+from threading import Thread
 
 SERVER = [
     "192.210.149.121",
@@ -167,14 +168,25 @@ class PrintBot(Tox):
             msg = "Thanks, I got {}, printing it right away!".format(filename)
             self.friend_send_message(fid, Tox.MESSAGE_TYPE_NORMAL, msg)
 
-            call(['printcore', '/dev/ttyUSB0', filename])
-
-            msg = "I am happy to report {} is printed!".format(filename)
-            self.friend_send_message(fid, Tox.MESSAGE_TYPE_NORMAL, msg)
+            thread = Thread(target=self.print_from_filename,
+                            args=(fid, filename))
+            thread.start()
             return
 
         self.files[(fid, filenumber)]['f'].write(data)
         print (fid, filenumber, position)
+
+    def print_from_filename(self, fid, filename):
+        # If you do not have a printer connected to the machine on which you
+        # test this script, the following line might be a good approximation of
+        # the actual printing (without the physical result of course).
+        #
+        # call(['sleep', '30'])
+
+        call(['printcore', '/dev/ttyUSB0', filename])
+
+        msg = "I am happy to report {} is printed!".format(filename)
+        self.friend_send_message(fid, Tox.MESSAGE_TYPE_NORMAL, msg)
 
     def connect(self):
         print('connecting...')


### PR DESCRIPTION
- Since printing is done by executing an external command which takes
  some time to finish, it is necessary to make sure this execution does
  not block other important functions, such as the heartbeat.
  
  This PR makes the command execute in a thread which fixes part of the
  problem.

Signed-off-by: mr.Shu mr@shu.io
